### PR TITLE
Fix 0.0.0.0 handling

### DIFF
--- a/src/Matcher.js
+++ b/src/Matcher.js
@@ -42,11 +42,12 @@ Matcher.prototype.removeNetworkClass = function(cidr) {
 };
 
 Matcher.prototype.contains = function(addr) {
-    // Convert to decimal
-    addr = ip.toLong(addr);
-    if (!addr) {
+    if (!ip.isV4Format(addr)) {
         return false;
     }
+
+    // Convert to decimal
+    addr = ip.toLong(addr);
 
     for (var i in this.ranges) {
         if (this.ranges.hasOwnProperty(i) && addr >= this.ranges[i][0] && addr <= this.ranges[i][1]) {

--- a/test/MatcherTest.js
+++ b/test/MatcherTest.js
@@ -108,6 +108,18 @@ describe('Matcher', function() {
             assert.ok(matcher.contains('192.168.1.128'));
             assert.ok(matcher.contains('192.168.1.254'));
         });
+
+        it('should return true if an IPv4 matches a 0.0.0.0 range', function() {
+            var matcher = new Matcher([ '0.0.0.0/24' ]);
+
+            assert.ok(!matcher.contains('butt'));
+            assert.ok(!matcher.contains('192.168.2.1'));
+            assert.ok(!matcher.contains('192.168.2.254'));
+
+            assert.ok(matcher.contains('0.0.0.0'));
+            assert.ok(matcher.contains('0.0.0.10'));
+            assert.ok(matcher.contains('0.0.0.254'));
+        });
     });
 
 

--- a/test/MatcherTest.js
+++ b/test/MatcherTest.js
@@ -6,6 +6,12 @@ describe('Matcher', function() {
 
     describe('contains()', function() {
 
+        it('should return false with a bad IPv4 address', function() {
+            var matcher = new Matcher([ '192.168.1.2' ]);
+
+            assert.ok(!matcher.contains('0.0.0.192.168.1.2'));
+        });
+
         it('should return true if an IPv4 matches a single IP address', function() {
             var matcher = new Matcher([ '192.168.1.2' ]);
 


### PR DESCRIPTION
The .contains() function will interpret addresses that ip.toLong() turns into zeros as invalid. That doesn't always work however:

1. 0.0.0.0 is a valid ip address that toLong turns into zero. This behavior makes it so that this address can't get matched by any CIDR range.

2. The ip.toLong() function actually doesn't validate the ip addresses it gets, so the zero checking will only sometimes catch bad formats.

This PR changes .contains() to use the ip.isV4Format() method instead of the zero check. Plus tests, because those are cool. :)
