### PR TITLE
Add benchmarks for netparser & net.BlockList

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,5 +1,6 @@
 const CIDRMatcherMaster = require("../src/Matcher");
 const CIDRMatcher105    = require("cidr-matcher");
+const netparser         = require("netparser");
 const { isInSubnet }    = require("is-in-subnet");
 const ipRangeCheck      = require("ip-range-check");
 
@@ -73,6 +74,20 @@ runBenchmark("node-cidr-matcher", "1.0.5", "ipv4", (cidrs, ips) => {
     let matcher = new CIDRMatcher105(cidrs);
     for (let i = 0; i < ips.length; i++) {
         matcher.contains(ips[i]);
+    }
+});
+
+runBenchmark("netparser", "1.8.1", "ipv4", (cidrs, ips) => {
+    let matcher = new netparser.Matcher(cidrs);
+    for (let i = 0; i < ips.length; i++) {
+        matcher.has(ips[i]);
+    }
+});
+
+runBenchmark("netparser", "1.8.1", "ipv6", (cidrs, ips) => {
+    let matcher = new netparser.Matcher(cidrs);
+    for (let i = 0; i < ips.length; i++) {
+        matcher.has(ips[i]);
     }
 });
 

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,5 +1,6 @@
 const CIDRMatcherMaster = require("../src/Matcher");
 const CIDRMatcher105    = require("cidr-matcher");
+const net               = require("net");
 const netparser         = require("netparser");
 const { isInSubnet }    = require("is-in-subnet");
 const ipRangeCheck      = require("ip-range-check");
@@ -90,6 +91,32 @@ runBenchmark("netparser", "1.8.1", "ipv6", (cidrs, ips) => {
         matcher.has(ips[i]);
     }
 });
+
+if (net.BlockList) {
+    runBenchmark("net.BlockList", process.versions.node, "ipv4", (cidrs, ips) => {
+        let matcher = new net.BlockList();
+        for (const cidr of cidrs) {
+            const [net, prefix] = cidr.split("/");
+            matcher.addSubnet(net, parseInt(prefix), "ipv4");
+        }
+        for (let i = 0; i < ips.length; i++) {
+            matcher.check(ips[i]);
+        }
+    });
+}
+
+if (net.BlockList) {
+    runBenchmark("net.BlockList", process.versions.node, "ipv6", (cidrs, ips) => {
+        let matcher = new net.BlockList();
+        for (const cidr of cidrs) {
+            const [net, prefix] = cidr.split("/");
+            matcher.addSubnet(net, parseInt(prefix), "ipv6");
+        }
+        for (let i = 0; i < ips.length; i++) {
+            matcher.check(ips[i]);
+        }
+    });
+}
 
 runBenchmark("node-cidr-matcher", "master", "ipv6", (cidrs, ips) => {
     let matcher = new CIDRMatcherMaster(cidrs);

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -39,6 +39,12 @@
       "resolved": "https://registry.npmjs.org/is-in-subnet/-/is-in-subnet-1.9.0.tgz",
       "integrity": "sha512-zx7GdTPsGrLNIWIx978xGPP6UUjXYH/gG0vFtUARakofU2m+uiMqbSTR/bKCXooHjhW2W1KUDrhuuiaCc27sog==",
       "dev": true
+    },
+    "netparser": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/netparser/-/netparser-1.8.1.tgz",
+      "integrity": "sha512-O5Atlt4P1br0EEcPbgdd6rHpN3SSBMFzikY1BFaRyugIs2gTBsXiR69eDjutTVIQ18D3kcKWPslVjk0nwRIv1Q==",
+      "dev": true
     }
   }
 }

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,7 +8,8 @@
   "devDependencies": {
     "cidr-matcher": "^1.0.5",
     "ip-range-check": "0.0.2",
-    "is-in-subnet": "^1.9.0"
+    "is-in-subnet": "^1.9.0",
+    "netparser": "^1.8.1"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This PR adds benchmarks for [netparser](https://www.npmjs.com/package/netparser), (which seems to use binary search to implement matching and is therefore quite fast) and the node.js built-in [net.BlockList](https://nodejs.org/api/net.html#net_class_net_blocklist) which was added in node.js v15 (and seems to be implemented in C++).